### PR TITLE
Upgrade Twig from Underscored to Namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 php:
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 env:

--- a/Command/DumpCommand.php
+++ b/Command/DumpCommand.php
@@ -28,12 +28,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DumpCommand extends AbstractCommand
 {
+    protected static $defaultName = 'assetic:dump';
     private $spork;
 
     protected function configure()
     {
         $this
-            ->setName('assetic:dump')
+            ->setName(static::$defaultName)
             ->setDescription('Dumps all assets to the filesystem')
             ->addArgument('write_to', InputArgument::OPTIONAL, 'Override the configured asset root')
             ->addOption('forks', null, InputOption::VALUE_REQUIRED, 'Fork work across many processes (requires kriswallsmith/spork)')

--- a/Command/WatchCommand.php
+++ b/Command/WatchCommand.php
@@ -25,10 +25,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class WatchCommand extends AbstractCommand
 {
+    protected static $defaultName = 'assetic:watch';
+
     protected function configure()
     {
         $this
-            ->setName('assetic:watch')
+            ->setName(static::$defaultName)
             ->setDescription('Dumps assets to the filesystem as their source files are modified')
             ->addArgument('write_to', InputArgument::OPTIONAL, 'Override the configured asset root')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Force an initial generation of all assets')

--- a/DependencyInjection/AsseticExtension.php
+++ b/DependencyInjection/AsseticExtension.php
@@ -36,6 +36,7 @@ class AsseticExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('assetic.xml');
+        $loader->load('commands.xml');
         $loader->load('templating_twig.xml');
         $loader->load('templating_php.xml');
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
     {
         $builder = new TreeBuilder('assetic');
         $finder = new ExecutableFinder();
-        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $builder->getRootNode() : $builder->root('assetic');
+        $rootNode = method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode') ? $builder->getRootNode() : $builder->root('assetic');
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,9 +46,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('assetic');
         $finder = new ExecutableFinder();
-        $rootNode = $builder->root('assetic');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $builder->getRootNode() : $builder->root('assetic');
 
         $rootNode
             ->children()

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.dump_command.class">Symfony\Bundle\AsseticBundle\Command\DumpCommand</parameter>
+        <parameter key="assetic.watch_command.class">Symfony\Bundle\AsseticBundle\Command\WatchCommand</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.command.dump" class="%assetic.dump_command.class%" public="true">
+            <tag name="console.command" command="assetic:dump" />
+        </service>
+        <service id="assetic.command.watch" class="%assetic.watch_command.class%" public="true">
+            <tag name="console.command" command="assetic:watch" />
+        </service>
+    </services>
+</container>

--- a/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -52,7 +52,7 @@ class AsseticExtensionTest extends \PHPUnit\Framework\TestCase
             $this->markTestSkipped('Assetic is not available.');
         }
 
-        if (!class_exists('Twig_Environment')) {
+        if (!class_exists('\Twig\Environment')) {
             $this->markTestSkipped('Twig is not available.');
         }
 
@@ -78,8 +78,8 @@ class AsseticExtensionTest extends \PHPUnit\Framework\TestCase
         $this->container->register('templating.helper.router', $this->getMockClass('Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\RouterHelper'))
             ->addArgument(new Definition($this->getMockClass('Symfony\\Component\\Routing\\RouterInterface')))
             ->setPublic(true);
-        $this->container->register('twig', 'Twig_Environment')
-            ->addArgument(new Definition($this->getMockClass('Twig_LoaderInterface')))
+        $this->container->register('twig', '\Twig\Environment')
+            ->addArgument(new Definition($this->getMockClass('\Twig\Loader\LoaderInterface')))
             ->setPublic(true);
         $this->container->setParameter('kernel.bundles', array());
         $this->container->setParameter('kernel.cache_dir', __DIR__);

--- a/Twig/AsseticNode.php
+++ b/Twig/AsseticNode.php
@@ -13,6 +13,14 @@ namespace Symfony\Bundle\AsseticBundle\Twig;
 
 use Assetic\Asset\AssetInterface;
 use Assetic\Extension\Twig\AsseticNode as BaseAsseticNode;
+use Twig\Compiler;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FunctionExpression;
+use Twig\Node\Expression\GetAttrExpression;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\Node;
+use Twig\Template;
 
 /**
  * Assetic node.
@@ -21,24 +29,24 @@ use Assetic\Extension\Twig\AsseticNode as BaseAsseticNode;
  */
 class AsseticNode extends BaseAsseticNode
 {
-    protected function compileAssetUrl(\Twig_Compiler $compiler, AssetInterface $asset, $name)
+    protected function compileAssetUrl(Compiler $compiler, AssetInterface $asset, $name)
     {
         $vars = array();
         foreach ($asset->getVars() as $var) {
-            $vars[] = new \Twig_Node_Expression_Constant($var, $this->getTemplateLine());
+            $vars[] = new ConstantExpression($var, $this->getTemplateLine());
 
             // Retrieves values of assetic vars from the context, $context['assetic']['vars'][$var].
-            $vars[] = new \Twig_Node_Expression_GetAttr(
-                new \Twig_Node_Expression_GetAttr(
-                    new \Twig_Node_Expression_Name('assetic', $this->getTemplateLine()),
-                    new \Twig_Node_Expression_Constant('vars', $this->getTemplateLine()),
-                    new \Twig_Node_Expression_Array(array(), $this->getTemplateLine()),
-                    \Twig_Template::ARRAY_CALL,
+            $vars[] = new GetAttrExpression(
+                new GetAttrExpression(
+                    new NameExpression('assetic', $this->getTemplateLine()),
+                    new ConstantExpression('vars', $this->getTemplateLine()),
+                    new ArrayExpression(array(), $this->getTemplateLine()),
+                    Template::ARRAY_CALL,
                     $this->getTemplateLine()
                 ),
-                new \Twig_Node_Expression_Constant($var, $this->getTemplateLine()),
-                new \Twig_Node_Expression_Array(array(), $this->getTemplateLine()),
-                \Twig_Template::ARRAY_CALL,
+                new ConstantExpression($var, $this->getTemplateLine()),
+                new ArrayExpression(array(), $this->getTemplateLine()),
+                Template::ARRAY_CALL,
                 $this->getTemplateLine()
             );
         }
@@ -52,15 +60,15 @@ class AsseticNode extends BaseAsseticNode
 
     private function getPathFunction($name, array $vars = array())
     {
-        $nodes = array(new \Twig_Node_Expression_Constant('_assetic_'.$name, $this->getTemplateLine()));
+        $nodes = array(new ConstantExpression('_assetic_'.$name, $this->getTemplateLine()));
 
         if (!empty($vars)) {
-            $nodes[] = new \Twig_Node_Expression_Array($vars, $this->getTemplateLine());
+            $nodes[] = new ArrayExpression($vars, $this->getTemplateLine());
         }
 
-        return new \Twig_Node_Expression_Function(
+        return new FunctionExpression(
             'path',
-            new \Twig_Node($nodes),
+            new Node($nodes),
             $this->getTemplateLine()
         );
     }
@@ -70,12 +78,12 @@ class AsseticNode extends BaseAsseticNode
         $arguments = array($path);
 
         if ($this->hasAttribute('package')) {
-            $arguments[] = new \Twig_Node_Expression_Constant($this->getAttribute('package'), $this->getTemplateLine());
+            $arguments[] = new ConstantExpression($this->getAttribute('package'), $this->getTemplateLine());
         }
 
-        return new \Twig_Node_Expression_Function(
+        return new FunctionExpression(
             'asset',
-            new \Twig_Node($arguments),
+            new Node($arguments),
             $this->getTemplateLine()
         );
     }
@@ -94,7 +102,7 @@ class TargetPathNode extends AsseticNode
         $this->name = $name;
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         BaseAsseticNode::compileAssetUrl($compiler, $this->asset, $this->name);
     }

--- a/Twig/AsseticTokenParser.php
+++ b/Twig/AsseticTokenParser.php
@@ -16,6 +16,9 @@ use Assetic\Extension\Twig\AsseticTokenParser as BaseAsseticTokenParser;
 use Symfony\Bundle\AsseticBundle\Exception\InvalidBundleException;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Component\Templating\TemplateNameParserInterface;
+use Twig\Node\Node;
+use Twig\NodeInterface;
+use Twig\Token;
 
 /**
  * Assetic token parser.
@@ -40,7 +43,7 @@ class AsseticTokenParser extends BaseAsseticTokenParser
         $this->enabledBundles = $enabledBundles;
     }
 
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         if ($this->templateNameParser && is_array($this->enabledBundles)) {
             // check the bundle
@@ -63,12 +66,12 @@ class AsseticTokenParser extends BaseAsseticTokenParser
         return parent::parse($token);
     }
 
-    protected function createBodyNode(AssetInterface $asset, \Twig_Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    protected function createBodyNode(AssetInterface $asset, Node $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         return new AsseticNode($asset, $body, $inputs, $filters, $name, $attributes, $lineno, $tag);
     }
 
-    protected function createNode(AssetInterface $asset, \Twig_NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
+    protected function createNode(AssetInterface $asset, NodeInterface $body, array $inputs, array $filters, $name, array $attributes = array(), $lineno = 0, $tag = null)
     {
         return new AsseticNode($asset, $body, $inputs, $filters, $name, $attributes, $lineno, $tag);
     }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "~2.3|~3.0|~4.0",
         "symfony/templating": "~2.3|~3.0|~4.0",
         "symfony/yaml": "~2.3|~3.0|~4.0",
-        "sanpi/assetic": "~1.5"
+        "sanpi/assetic": "^1.6"
     },
     "require-dev": {
         "patchwork/jsqueeze": "~1.0",
@@ -36,7 +36,7 @@
         "symfony/assetic-bundle": "self.version"
     },
     "conflict": {
-        "twig/twig": "<1.27",
+        "twig/twig": "<1.34|>=2,<2.4",
         "kriswallsmith/spork": "<=0.2"
     },
     "suggest": {


### PR DESCRIPTION
The main reason for this is because Twig shows the deprecation notice like
> User Deprecated: Using the "Twig_Source" class is deprecated since Twig version 2.7, use "Twig\Source" instead.

Set `sanpii/assetic` to the latest version when it will be released with https://github.com/sanpii/assetic/pull/1 before merging this.